### PR TITLE
Add Keyboard Shortcut for Opening and Focusing DevChat View

### DIFF
--- a/src/views/components/InputMessage/index.tsx
+++ b/src/views/components/InputMessage/index.tsx
@@ -195,6 +195,12 @@ const InputMessage = observer((props: any) => {
       }
     );
     messageUtil.registerHandler(
+      "focusDevChatInput",
+      (message: { command: string; message: string }) => {
+        inputRef.current.focus();
+      }
+    );
+    messageUtil.registerHandler(
       "appendContext",
       (message: { command: string; context: string }) => {
         // context is a temp file path


### PR DESCRIPTION
This pull request introduces a new feature allowing users to open the DevChat view and focus the input field using a keyboard shortcut. This action implements the feature requested in issue [#250](https://github.com/devchat-ai/devchat/issues/250), aimed at streamlining the user experience by reducing the need to switch between keyboard and mouse, thereby improving efficiency for discussions and notes related to code segments.

**Key Changes:**

- A keyboard shortcut handler dubbed 'focusDevChatInput' was implemented to streamline the process of opening the DevChat panel and focusing on the input box instantly.

- The usability of DevChat for keyboard-centric users has been substantially enhanced, adhering to the benefits outlined in the feature request.

Ref: devchat-ai/devchat#250.