### PR TITLE
Fix rendering issue in VSCode for first-time devchat installation

### DIFF
--- a/src/views/stores/ConfigStore.ts
+++ b/src/views/stores/ConfigStore.ts
@@ -68,21 +68,16 @@ export const ConfigStore = types
       this.updateSettle(false);
       let needUpdate = false;
       const newConfig = { ...data };
-      if (!data.models) {
-        newConfig.models = {};
-      }
-      if (!newConfig.providers?.openai) {
-        newConfig.providers.openai = {
-          api_key: "",
-          api_base: "",
-        };
-      }
-      if (!newConfig.providers?.devchat) {
-        newConfig.providers.devchat = {
-          api_key: "",
-          api_base: "",
-        };
-      }
+      newConfig.models = newConfig.models || {};
+      newConfig.providers = newConfig.providers || {};
+      newConfig.providers.openai = newConfig.providers.openai || {
+        api_key: "",
+        api_base: "",
+      };
+      newConfig.providers.devchat = newConfig.providers.devchat || {
+        api_key: "",
+        api_base: "",
+      };
 
       self.modelsTemplate.forEach((item) => {
         const currentModel: any = {


### PR DESCRIPTION
This pull request addresses the problem where devchat would fail to render properly in VSCode on machines without a prior installation (#347). By streamlining the config model initialization and ensuring default provider settings are applied during the first access, we prevent exceptions that could disrupt the execution flow. This enhances the user experience, especially for first-time users.

## Changes
- Simplified provider configuration within the `ConfigStore`.
- Applied logical OR operation to assign default settings for openai and devchat providers.

This should resolve the initialization issues as highlighted in issue [#347](https://github.com/devchat-ai/devchat/issues/347). With these changes, new users should be able to launch devchat seamlessly in VSCode. 

Closes devchat-ai/devchat#347