### PR TITLE
chore: Add completion context length configuration

### DIFF
--- a/src/views/i18n/zh.json
+++ b/src/views/i18n/zh.json
@@ -51,6 +51,8 @@
   "Proxy setting": "代理设置",
   "Code Completion Enable": "代码补全启用",
   "Codebase Index Enable": "代码库索引启用",
+  "The maximum number of tokens to use as context for the model": "模型上下文的最大令牌数",
+  "Completion Context Length": "补全上下文长度",
   "Code Completion Model": "代码补全模型",
   "Select a model": "选择补全模型",
   "Please enter the path of your python": "请输入你的 Python 路径",

--- a/src/views/pages/Config.tsx
+++ b/src/views/pages/Config.tsx
@@ -443,6 +443,13 @@ const Config = observer(() => {
               label={t("Codebase Index Enable")}
               {...form.getInputProps('complete_index_enable', { type: 'checkbox' })}
             />
+            <TextInput
+              styles={commonInputStyle}
+              label={t("Completion Context Length")}
+              placeholder="5000"
+              description={t("The maximum number of tokens to use as context for the model")}
+              {...form.getInputProps("complete_context_limit")}
+            />
             <Select
               styles={{
                 ...commonInputStyle,


### PR DESCRIPTION
This pull request adds the configuration for completion context length. It includes:

- Added translation for 'Completion Context Length' and 'The maximum number of tokens to use as context for the model' in zh.json
- Integrated TextInput component for user input of completion context limit in Config.tsx