### PR TITLE
feat: Limit EditApplyButton to 'edits' language

### DIFF
--- a/src/views/components/MessageMarkdown/CodeButtons.tsx
+++ b/src/views/components/MessageMarkdown/CodeButtons.tsx
@@ -125,7 +125,9 @@ const CodeButtons = ({ platform, language, code }) => (
         <CodeCopyButton code={code} language={language} platform={platform} />
         <>
             <DiffButton code={code} language={language} platform={platform} />
-            <EditApplyButton code={code} language={language} platform={platform} />
+            {language === 'edits' && (
+                <EditApplyButton code={code} language={language} platform={platform} />
+            )}
             <CodeApplyButton code={code} language={language} platform={platform} />
             <FileApplyButton code={code} language={language} platform={platform} />
             <NewFileButton code={code} language={language} platform={platform} />


### PR DESCRIPTION
This PR limits the EditApplyButton rendering to the 'edits' language only. It wraps the EditApplyButton in a conditional statement and improves code clarity and functionality in the CodeButtons component.

Changes made:
- Restricted EditApplyButton rendering to 'edits' language only
- Wrapped EditApplyButton in conditional statement
- Improved code clarity and functionality in CodeButtons component