### PR TITLE
fix: Add focus and prevent default on message send

### DIFF
--- a/src/views/components/InputMessage/index.tsx
+++ b/src/views/components/InputMessage/index.tsx
@@ -92,6 +92,7 @@ const InputMessage = observer((props: any) => {
     if (inputRef.current) {
       inputRef.current.selectionStart = 0;
       inputRef.current.selectionEnd = 0;
+      inputRef.current.focus();
     }
   };
 
@@ -178,6 +179,7 @@ const InputMessage = observer((props: any) => {
         !event.nativeEvent.isComposing
       ) {
         handleSendClick(event as any);
+        event.preventDefault();
       }
     }
   };


### PR DESCRIPTION
This PR improves the user experience in the message input component by:

- Adding focus to the input after sending a message
- Preventing default behavior on Enter key press
- Improving overall interaction in the message input component

These changes should make the messaging experience smoother and more intuitive for users.